### PR TITLE
Add env setup to starter files from lab issues and fixed a couple typos

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -173,7 +173,7 @@ Ex: `restock formula tool used specifically for calculating the amount of food a
 
 ### Scenario 2 sub-problem: structured output
 
-At this stage, you may that your agent is returning a "correct" answer to the question but not in the **format** the test script expects. The test script expects answers to multiple choice questions to be the single character "A", "B", "C", or "D". This may seem contrived, but often in production scenarios agents will be expected to work with existing deterministic systems that will require specific schemas. For this reason, LangChain supports an LLM call `with_structured_output` so that response can come from a predictable structure.
+At this stage, you may notice that your agent is returning a "correct" answer to the question but not in the **format** the test script expects. The test script expects answers to multiple choice questions to be the single character "A", "B", "C", or "D". This may seem contrived, but often in production scenarios agents will be expected to work with existing deterministic systems that will require specific schemas. For this reason, LangChain supports an LLM call `with_structured_output` so that response can come from a predictable structure.
 
 ### Steps:
 - Open [participant_agent/utils/state.py](participant_agent/utils/state.py) and uncomment the multi_choice_response attribute on the state parameter. To this point our state has only had one attribute called `messages` but we are adding a specific field that we will add structured outputs to.

--- a/participant_agent/utils/router.py
+++ b/participant_agent/utils/router.py
@@ -10,7 +10,7 @@ REDIS_URL = os.environ.get("REDIS_URL", "redis://host.docker.internal:6379/0")
 
 # Semantic router
 blocked_references = [
-    "thinks about aliens",
+    "things about aliens",
     "corporate questions about agile",
     "anything about the S&P 500",
 ]

--- a/participant_agent/utils/router.py
+++ b/participant_agent/utils/router.py
@@ -1,7 +1,10 @@
 import os
 
+from dotenv import load_dotenv
 from redisvl.extensions.router import Route, SemanticRouter
 from redisvl.utils.vectorize import HFTextVectorizer
+
+load_dotenv()
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://host.docker.internal:6379/0")
 

--- a/participant_agent/utils/semantic_cache.py
+++ b/participant_agent/utils/semantic_cache.py
@@ -1,6 +1,9 @@
 import os
 
+from dotenv import load_dotenv
 from redisvl.extensions.llmcache import SemanticCache
+
+load_dotenv()
 
 REDIS_URL = os.environ.get("REDIS_URL", "redis://host.docker.internal:6379/0")
 


### PR DESCRIPTION
Noticed a couple typos and during the lab I had to add the env setup code in these two files to get it working. 

I could replace the instances of redis://host.docker.internal:6379/0 with this redis://localhost:6379/0 too. But since that is just a default if the env is not in place I figured it could be left for your testing unless you just want that cleaned up.